### PR TITLE
Fix CVE errors in OWASP check

### DIFF
--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -61,7 +61,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
-    implementation("org.springframework.ws:spring-ws-security")
+    implementation("org.springframework.ws:spring-ws-security") {
+        exclude("org.opensaml")
+    }
 
     implementation("com.zaxxer:HikariCP:6.2.1")
     implementation("org.flywaydb:flyway-core")


### PR DESCRIPTION
Fixes error in dependency check:
`One or more dependencies were identified with vulnerabilities that have a CVSS score greater than '0.0': CVE-2024-30171, CVE-2024-34447, CVE-2020-15522, CVE-2024-29857, CVE-2018-1000613, CVE-2023-33202, CVE-2020-0187, CVE-2023-33201, CVE-2018-1000180, CVE-2020-26939`

`org.opensaml` does not seem to be in use, so it's excluded.