### PR TITLE
Migrate OSS Index to Sonatype Guide API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,13 +167,14 @@ jobs:
         with:
           mask-password: 'true'
 
-      - name: Cache dependency check database
-        uses: actions/cache@v5
+      - name: Load OWASP cache
+        id: owasp_cache
+        uses: espoon-voltti/voltti-actions/owasp-cache-get@feature/owasp-cache-get
         with:
-          path: dependency-check-data
-          key: dependency-check-data-${{ github.run_id }}-${{ github.run_attempt }}
-          restore-keys: |
-            dependency-check-data-
+          gh_token: ${{ secrets.VOLTTI_OWASP_TOKEN }}
+          t_cache_base: "./"
+          t_cache_dir: "dependency-check-data"
+          fail_on_miss: "true"
 
       - name: Run service OWASP tests
         shell: bash
@@ -183,14 +184,7 @@ jobs:
               -e OSS_INDEX_USERNAME=${{ secrets.OSS_INDEX_USERNAME }} -e OSS_INDEX_PASSWORD=${{ secrets.OSS_INDEX_PASSWORD }} \
               -v $(pwd)/dependency-check-data:/root/.gradle/dependency-check-data \
               ${{ needs.service.outputs.builder_image }} \
-              sh -c "./gradlew --no-daemon dependencyCheckUpdate && ./gradlew --no-daemon dependencyCheckAnalyze"
-
-      - name: Force caching dependency-check-data # If job fails cache is not saved without this
-        uses: actions/cache/save@v5
-        if: failure()
-        with:
-          path: dependency-check-data
-          key: dependency-check-data-${{ github.run_id }}-${{ github.run_attempt }}
+              sh -c "./gradlew --no-daemon dependencyCheckAnalyze"
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Load OWASP cache
         id: owasp_cache
-        uses: espoon-voltti/voltti-actions/owasp-cache-get@feature/owasp-cache-get
+        uses: espoon-voltti/voltti-actions/owasp-cache-get@master
         with:
           gh_token: ${{ secrets.VOLTTI_OWASP_TOKEN }}
           t_cache_base: "./"

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -26,7 +26,7 @@ RUN yarn lint
 
 FROM builder
 
-ENV NODE_ENV production
+ENV NODE_ENV="production"
 
 ARG S3_DOWNLOADER_VERSION=v1.5.1
 ARG S3_DOWNLOADER_SHA256="cb751589ca60749c42b65009671d6076435e7454b8980ee98884e296a1ec6cb8"
@@ -42,8 +42,8 @@ RUN apt-get update \
 ARG build=none
 ARG commit=none
 
-ENV APP_BUILD "$build"
-ENV APP_COMMIT "$commit"
+ENV APP_BUILD="$build" \
+    APP_COMMIT="$commit"
 
 LABEL fi.espoo.build="$build" \
       fi.espoo.commit="$commit"

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -170,6 +170,7 @@ tasks {
             ossIndex.apply {
                 username = System.getenv("OSS_INDEX_USERNAME")
                 password = System.getenv("OSS_INDEX_PASSWORD")
+                url = "https://api.guide.sonatype.com"
             }
         }
         nvd.apply { apiKey = System.getenv("NVD_API_KEY") }


### PR DESCRIPTION
Update ossIndex URL to https://api.guide.sonatype.com for the OWASP dependency-check plugin as required by the OSS Index migration to Sonatype Guide (deadline: April 28, 2026).