### PR TITLE
Push images to ESC ECR and deploy esc-staging alongside staging/prod

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
     - cron: "0 1 * * 1" # At 01:00 on Monday
 env:
   AWS_REGION: eu-north-1
+  AWS_REGION_ESC: eusc-de-east-1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -335,6 +336,50 @@ jobs:
             docker buildx imagetools create --prefer-index=false --tag "${dst}" "${src}"
           done
 
+  ecr-push-esc:
+    if: ${{ github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
+    needs:
+      - dockerize
+      - service
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials (ESC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ env.AWS_REGION_ESC }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ESC }}
+          role-duration-seconds: 1200
+          mask-aws-account-id: false
+
+      - name: Login to Amazon ECR (ESC)
+        id: ecr-esc
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          mask-password: 'true'
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Copy images from GHCR to ESC ECR
+        env:
+          SHA: "${{ github.event.pull_request.head.sha || github.sha }}"
+          ECR: "${{ steps.ecr-esc.outputs.registry }}"
+        run: |
+          set -euo pipefail
+          for image in frontend api-gateway service; do
+            src="ghcr.io/espoon-voltti/oppivelvollisuus/${image}:${SHA}"
+            dst="${ECR}/oppivelvollisuus/${image}:${SHA}"
+            echo "Copying ${src} -> ${dst}"
+            docker buildx imagetools create --prefer-index=false --tag "${dst}" "${src}"
+          done
+
   deploy:
     if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
@@ -342,12 +387,24 @@ jobs:
       - test
       - e2e-test
       - ecr-push
+      - ecr-push-esc
     strategy:
       fail-fast: false
       matrix:
         environment:
           - staging
           - prod
+          - esc-staging
+        include:
+          - environment: staging
+            aws_region: eu-north-1
+            ecr_role_secret: AWS_ROLE
+          - environment: prod
+            aws_region: eu-north-1
+            ecr_role_secret: AWS_ROLE
+          - environment: esc-staging
+            aws_region: eusc-de-east-1
+            ecr_role_secret: AWS_ROLE_ESC
     environment:
       name: ${{ matrix.environment }}
 
@@ -355,8 +412,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-region: ${{ env.AWS_REGION }}
-          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ matrix.aws_region }}
+          role-to-assume: ${{ secrets[matrix.ecr_role_secret] }}
           role-duration-seconds: 1200
 
       - name: Retag
@@ -369,7 +426,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ matrix.aws_region }}
           role-to-assume: ${{ secrets.AWS_ROLE_ENVIRONMENT }}
           role-duration-seconds: 1200
           unset-current-credentials: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -398,22 +398,28 @@ jobs:
         include:
           - environment: staging
             aws_region: eu-north-1
-            ecr_role_secret: AWS_ROLE
           - environment: prod
             aws_region: eu-north-1
-            ecr_role_secret: AWS_ROLE
           - environment: esc-staging
             aws_region: eusc-de-east-1
-            ecr_role_secret: AWS_ROLE_ESC
     environment:
       name: ${{ matrix.environment }}
 
     steps:
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (staging/prod)
+        if: ${{ matrix.environment == 'staging' || matrix.environment == 'prod' }}
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ matrix.aws_region }}
-          role-to-assume: ${{ secrets[matrix.ecr_role_secret] }}
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          role-duration-seconds: 1200
+
+      - name: Configure AWS credentials (esc-staging)
+        if: ${{ matrix.environment == 'esc-staging' }}
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ matrix.aws_region }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ESC }}
           role-duration-seconds: 1200
 
       - name: Retag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -429,7 +429,7 @@ jobs:
             aws ecr put-image --repository-name "oppivelvollisuus/$repository" --image-tag "env-${{ matrix.environment }}" --image-manifest "$MANIFEST"
           done
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (deploy role)
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ matrix.aws_region }}

--- a/frontend/src/shared/form/InputField.tsx
+++ b/frontend/src/shared/form/InputField.tsx
@@ -192,9 +192,7 @@ interface OtherInputProps extends InputProps {
 }
 
 export type TextInputProps =
-  | OtherInputProps
-  | DateInputProps
-  | ClearableInputProps
+  OtherInputProps | DateInputProps | ClearableInputProps
 
 export const InputField = React.memo(function InputField({
   value,

--- a/frontend/src/shared/theme.ts
+++ b/frontend/src/shared/theme.ts
@@ -58,11 +58,13 @@ export const inputWidthCss = (width: InputWidth) => css`
   max-width: ${inputWidths[width]};
 
   @media (max-width: ${tabletMin}) {
-    ${width === 'L' || width === 'XL'
-      ? css`
-          width: 100%;
-          max-width: 100%;
-        `
-      : ''}
+    ${
+      width === 'L' || width === 'XL'
+        ? css`
+            width: 100%;
+            max-width: 100%;
+          `
+        : ''
+    }
   }
 `


### PR DESCRIPTION
CI didn't push container images to ECR in the AWS European Sovereign
Cloud (ESC), so oppivelvollisuus-infra's esc-staging environment had to
be seeded manually via bin/copy-ecr-images-to-esc.py. Add an
ecr-push-esc job that authenticates via the ESC-account GitHub OIDC
role (AWS_ROLE_ESC) and copies GHCR images straight to ESC ECR by SHA
tag, mirroring the existing ecr-push job.

Also add esc-staging as a third deploy matrix entry alongside
staging/prod, since region and the retag step's shared-account role
now differ per entry across partitions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
