### PR TITLE
Use shared voltti-actions/ghcr-cleanup

### DIFF
--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -43,21 +43,10 @@ jobs:
           - oppivelvollisuus/service
           - oppivelvollisuus/service-builder
     steps:
-      - name: Delete untagged versions of ${{ matrix.package }}
-        uses: actions/delete-package-versions@v5
+      - uses: espoon-voltti/voltti-actions/ghcr-cleanup@master
         with:
-          owner: espoon-voltti
-          package-name: ${{ matrix.package }}
-          package-type: container
-          delete-only-untagged-versions: 'true'
-
-      - name: Keep newest 100 versions of ${{ matrix.package }}
-        uses: actions/delete-package-versions@v5
-        with:
-          owner: espoon-voltti
-          package-name: ${{ matrix.package }}
-          package-type: container
-          min-versions-to-keep: 100
+          package: ${{ matrix.package }}
+          keep: 100
 
   keep-one:
     if: ${{ github.event.schedule == '17 2 * * 0' || github.event.inputs.mode == 'keep-1' }}
@@ -73,18 +62,7 @@ jobs:
           - oppivelvollisuus/service
           - oppivelvollisuus/service-builder
     steps:
-      - name: Delete untagged versions of ${{ matrix.package }}
-        uses: actions/delete-package-versions@v5
+      - uses: espoon-voltti/voltti-actions/ghcr-cleanup@master
         with:
-          owner: espoon-voltti
-          package-name: ${{ matrix.package }}
-          package-type: container
-          delete-only-untagged-versions: 'true'
-
-      - name: Keep only the newest version of ${{ matrix.package }}
-        uses: actions/delete-package-versions@v5
-        with:
-          owner: espoon-voltti
-          package-name: ${{ matrix.package }}
-          package-type: container
-          min-versions-to-keep: 1
+          package: ${{ matrix.package }}
+          keep: 1


### PR DESCRIPTION
Replace the two actions/delete-package-versions steps per job with the new espoon-voltti/voltti-actions ghcr-cleanup action. That action deletes untagged versions (keep=0) or keeps only the newest N (keep=100 / keep=1) in one hardened, 404-tolerant implementation, instead of an action that aborts on GHCR's routine "Package not found" 404s.

Depends on the ghcr-cleanup action being merged to voltti-actions master.