### PR TITLE
Fix OWASP dependency-check failures in service

### DIFF
--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -22,8 +22,16 @@ plugins {
 
 java { sourceCompatibility = JavaVersion.VERSION_25 }
 
-// CVE-2026-43515, CVE-2026-43512; overrides Spring Boot 4.0.6's tomcat 11.0.21
-extra["tomcat.version"] = "11.0.22"
+// CVE-2026-53434, CVE-2026-53404, CVE-2026-55276, CVE-2026-55955, CVE-2026-55956,
+// CVE-2026-50229, CVE-2026-59083, CVE-2026-59084; overrides Spring Boot 4.1.0's tomcat 11.0.22
+extra["tomcat.version"] = "11.0.24"
+
+// CVE-2026-49844; overrides Spring Boot 4.1.0's log4j 2.25.4
+extra["log4j2.version"] = "2.25.5"
+
+// CVE-2026-54515; overrides Spring Boot 4.1.0's Jackson 2 BOM 2.21.4.
+// Jackson 3 (jackson-bom.version) resolves to 4.1.0's 3.1.4, which is already fixed.
+extra["jackson-2-bom.version"] = "2.21.5"
 
 repositories { mavenCentral() }
 

--- a/service/owasp-suppressions.xml
+++ b/service/owasp-suppressions.xml
@@ -17,4 +17,25 @@ SPDX-License-Identifier: LGPL-2.1-or-later
        <cve>CVE-2026-34486</cve>
        <cve>CVE-2026-34487</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        CVE-2026-53914: code execution via unsafe deserialization in Kotlin build cache
+        metadata. Build-time only, not reachable in the deployed service. Fixed in Kotlin
+        2.4.20, which has no stable release yet (2.4.20-Beta2 as of 2026-08).
+        Remove this suppression when Kotlin 2.4.20 is released and the plugins are bumped.
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/.*$</packageUrl>
+       <cve>CVE-2026-53914</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        CVE-2026-66299: resource exhaustion in Tomcat's WebSocket chat *example* web
+        application, which embedded Tomcat does not ship at all. Matched only on the
+        apache:tomcat CPE version, not on code present in tomcat-embed-core.
+        Affects <= 11.0.24; 11.0.25 fixes it but is not released yet, so this cannot be
+        cleared by a version bump. Remove once we are on tomcat 11.0.25 or later.
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/.*$</packageUrl>
+       <cve>CVE-2026-66299</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Stacked on #1640 — based on `fix-ktfmt-0.27-reformat` so CI can get past `ktfmtCheck` and actually reach the `owasp` job. GitHub will retarget this to `master` automatically once #1640 merges. Review only the second commit.

## Why

`owasp` runs `dependencyCheckAnalyze` with `failBuildOnCVSS = 0.0f`, so any unsuppressed finding is fatal. It currently reports 12:

| Dependency | CVEs | Action |
|---|---|---|
| tomcat-embed 11.0.22 | 53434, 53404, 55276, 55955, 55956, 50229, 59083, 59084 | → **11.0.24** |
| log4j 2.25.4 | 49844 | → **2.25.5** |
| jackson-databind 2.21.4 | 54515 | → **2.21.5** |
| kotlin 2.4.10 | 53914 | suppress |
| tomcat-embed 11.0.24 | 66299 | suppress |

All three bumps are Spring Boot 4.1.0 BOM properties (`tomcat.version`, `log4j2.version`, `jackson-2-bom.version`), overridden with the same `extra[...]` mechanism the file already used for tomcat.

Version choices avoid two traps: log4j **2.26.0 is also affected** by CVE-2026-49844, and jackson-databind **2.22.0 is also affected** by CVE-2026-54515. 2.25.5 and 2.21.5 are the correct targets, not "latest".

Jackson 3 needs nothing — `tools.jackson` resolves to 3.1.4, which is the fixed version for CVE-2026-54515.

## The two suppressions

**CVE-2026-53914** (Kotlin, 6.7) — code execution via unsafe deserialization in *build cache metadata*. Build-time only, not reachable in the deployed service. Fixed in Kotlin 2.4.20, which has no stable release (2.4.20-Beta2 is the newest on Maven Central).

**CVE-2026-66299** (Tomcat, 7.5) — resource exhaustion in the WebSocket **chat example web application**. Embedded Tomcat doesn't ship the examples webapp at all; dependency-check matches on the `cpe:2.3:a:apache:tomcat` version string, not on code that's present. NVD: *"Users who have followed the security guidance to remove the examples web application are not affected."* Fixed in 11.0.25, which is not released — so this one cannot be cleared by bumping.

Both are scoped by `packageUrl` rather than a bare `<cve>`, so they can't silently mask the same CVE in an unrelated dependency, and both carry a note saying when to remove them.

## Also

The old tomcat comment was stale — it cited Spring Boot 4.0.6 and tomcat 11.0.21, but the 4.1.0 BOM already ships 11.0.22, so the pin had quietly become a no-op. Updated.

## Verified

- `dependencyInsight` confirms resolution: tomcat-embed-core **11.0.24**, log4j-api **2.25.5**, jackson-databind **2.21.5**
- `./gradlew ktfmtCheck ktlintCheck compileKotlin compileTestKotlin compileE2eTestKotlin` — BUILD SUCCESSFUL
- Suppression XML parses
- Full `dependencyCheckAnalyze` not run locally (needs an NVD API key and a fresh DB download) — CI is the real check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KF9CeTkGKeyubxGerZiqB6